### PR TITLE
feat: generalize LLM API to support OpenAI-compatible providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,1 @@
-OPENAI_API_KEY=your_openai_api_key
+LLM_API_KEY=your_llm_api_key

--- a/config/config.toml
+++ b/config/config.toml
@@ -5,6 +5,7 @@ port = 8080
 [llm]
 provider = "openai"
 model = "o4-mini"
+base_url = "https://api.openai.com/v1"
 
 [database]
 type = "ferretdb"

--- a/config/models.py
+++ b/config/models.py
@@ -9,6 +9,7 @@ class ServerConfig(BaseModel):
 class LLMConfig(BaseModel):
     provider: str = "openai"
     model: str = "o4-mini"
+    base_url: str = "https://api.openai.com/v1"
 
 
 class DatabaseConfig(BaseModel):

--- a/src/service/deliverable_service.py
+++ b/src/service/deliverable_service.py
@@ -7,6 +7,7 @@ from typing import Any
 import httpx
 from pypdf import PdfReader
 
+from config.config import get_config
 from src.repository.db.factory import get_database_repository
 from src.repository.db.models import DeliverableModel
 
@@ -18,7 +19,10 @@ class DeliverableService:
 
     def __init__(self) -> None:
         self.db_repository = get_database_repository()
-        self.openai_api_key = os.getenv("OPENAI_API_KEY", "")
+        self.llm_api_key = os.getenv("LLM_API_KEY", "")
+        config = get_config()
+        self.llm_base_url = config.llm.base_url
+        self.llm_model = config.llm.model
 
     def extract_student_name_from_pdf(self, pdf_content: bytes) -> tuple[str, str | None]:
         """Extract student name from PDF content using PyPDF2.
@@ -48,8 +52,8 @@ class DeliverableService:
 
             student_name = self.extract_name_from_text(extracted_text)
 
-            if student_name == "Unknown" and self.openai_api_key and extracted_text:
-                student_name = self.extract_name_with_openai(extracted_text[:2000])
+            if student_name == "Unknown" and self.llm_api_key and extracted_text:
+                student_name = self.extract_name_with_llm(extracted_text[:2000])
 
             return (student_name, extracted_text[:5000] if extracted_text else None)
 
@@ -57,8 +61,8 @@ class DeliverableService:
             logger.error(f"Failed to extract text from PDF: {e}")
             return ("Unknown", None)
 
-    def extract_name_with_openai(self, text: str) -> str:
-        """Extract student name using OpenAI API.
+    def extract_name_with_llm(self, text: str) -> str:
+        """Extract student name using LLM API (OpenAI-compatible).
 
         Args:
             text: The extracted text from the PDF.
@@ -67,8 +71,8 @@ class DeliverableService:
             The extracted student name or "Unknown".
         """
         try:
-            url = "https://api.openai.com/v1/chat/completions"
-            headers = {"Authorization": f"Bearer {self.openai_api_key}", "Content-Type": "application/json"}
+            url = f"{self.llm_base_url}/chat/completions"
+            headers = {"Authorization": f"Bearer {self.llm_api_key}", "Content-Type": "application/json"}
 
             prompt = (
                 "Extract the student's full name from the following text. "
@@ -79,7 +83,7 @@ class DeliverableService:
             )
 
             data: dict[str, Any] = {
-                "model": "gpt-3.5-turbo",
+                "model": self.llm_model,
                 "messages": [
                     {
                         "role": "system",
@@ -100,15 +104,15 @@ class DeliverableService:
                 cleaned_name = self.clean_student_name(name)
 
                 if cleaned_name != "Unknown":
-                    logger.info(f"OpenAI extracted student name: {cleaned_name}")
+                    logger.info(f"LLM extracted student name: {cleaned_name}")
                     return cleaned_name
             else:
-                logger.warning(f"OpenAI API returned status {response.status_code}")
+                logger.warning(f"LLM API returned status {response.status_code}")
 
         except httpx.TimeoutException:
-            logger.warning("OpenAI API request timed out")
+            logger.warning("LLM API request timed out")
         except Exception as e:
-            logger.error(f"Failed to extract name with OpenAI: {e}")
+            logger.error(f"Failed to extract name with LLM: {e}")
 
         return "Unknown"
 

--- a/tests/unit/service/test_deliverable_service.py
+++ b/tests/unit/service/test_deliverable_service.py
@@ -103,17 +103,17 @@ class TestDeliverableService:
 
     @patch("src.service.deliverable_service.httpx.post")
     @patch("src.service.deliverable_service.get_database_repository")
-    def test_extract_name_with_openai_success(self, mock_get_repo: MagicMock, mock_post: MagicMock) -> None:
-        """Test successful name extraction with OpenAI."""
+    def test_extract_name_with_llm_success(self, mock_get_repo: MagicMock, mock_post: MagicMock) -> None:
+        """Test successful name extraction with LLM."""
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = {"choices": [{"message": {"content": "John Smith"}}]}
         mock_post.return_value = mock_response
 
         service = DeliverableService()
-        service.openai_api_key = "test_key"
+        service.llm_api_key = "test_key"
 
-        name = service.extract_name_with_openai("Some text")
+        name = service.extract_name_with_llm("Some text")
         assert name == "John Smith"
 
     @patch("src.service.deliverable_service.httpx.post")
@@ -122,20 +122,20 @@ class TestDeliverableService:
         "exception,expected_log",
         [
             (Exception("API error"), None),
-            (httpx.TimeoutException("Timeout"), "OpenAI API request timed out"),
+            (httpx.TimeoutException("Timeout"), "LLM API request timed out"),
         ],
     )
-    def test_extract_name_with_openai_exceptions(
+    def test_extract_name_with_llm_exceptions(
         self, mock_get_repo: MagicMock, mock_post: MagicMock, exception: Exception, expected_log: str
     ) -> None:
-        """Test OpenAI extraction with various exceptions."""
+        """Test LLM extraction with various exceptions."""
         mock_post.side_effect = exception
 
         service = DeliverableService()
-        service.openai_api_key = "test_key"
+        service.llm_api_key = "test_key"
 
         with patch("src.service.deliverable_service.logger") as mock_logger:
-            name = service.extract_name_with_openai("Some text")
+            name = service.extract_name_with_llm("Some text")
             assert name == "Unknown"
 
             if expected_log:
@@ -143,38 +143,38 @@ class TestDeliverableService:
 
     @patch("src.service.deliverable_service.httpx.post")
     @patch("src.service.deliverable_service.get_database_repository")
-    def test_extract_name_with_openai_non_200_status(self, mock_get_repo: MagicMock, mock_post: MagicMock) -> None:
-        """Test OpenAI API non-200 status code (lines 111-119)."""
+    def test_extract_name_with_llm_non_200_status(self, mock_get_repo: MagicMock, mock_post: MagicMock) -> None:
+        """Test LLM API non-200 status code."""
         mock_response = MagicMock()
         mock_response.status_code = 400
         mock_post.return_value = mock_response
 
         service = DeliverableService()
-        service.openai_api_key = "test_key"
+        service.llm_api_key = "test_key"
 
         with patch("src.service.deliverable_service.logger") as mock_logger:
-            name = service.extract_name_with_openai("Some text")
+            name = service.extract_name_with_llm("Some text")
             assert name == "Unknown"
-            mock_logger.warning.assert_called_with("OpenAI API returned status 400")
+            mock_logger.warning.assert_called_with("LLM API returned status 400")
 
     @patch("src.service.deliverable_service.logger")
     @patch("src.service.deliverable_service.httpx.post")
     @patch("src.service.deliverable_service.get_database_repository")
-    def test_extract_name_with_openai_cleans_result(
+    def test_extract_name_with_llm_cleans_result(
         self, mock_get_repo: MagicMock, mock_post: MagicMock, mock_logger: MagicMock
     ) -> None:
-        """Test OpenAI result cleaning (line 110)."""
+        """Test LLM result cleaning."""
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = {"choices": [{"message": {"content": "Name: John Smith"}}]}
         mock_post.return_value = mock_response
 
         service = DeliverableService()
-        service.openai_api_key = "test_key"
+        service.llm_api_key = "test_key"
 
-        name = service.extract_name_with_openai("Some text")
+        name = service.extract_name_with_llm("Some text")
         assert name == "John Smith"
-        mock_logger.info.assert_called_with("OpenAI extracted student name: John Smith")
+        mock_logger.info.assert_called_with("LLM extracted student name: John Smith")
 
     @patch("src.service.deliverable_service.get_database_repository")
     @pytest.mark.parametrize(
@@ -495,10 +495,10 @@ class TestDeliverableService:
 
     @patch("src.service.deliverable_service.PdfReader")
     @patch("src.service.deliverable_service.get_database_repository")
-    def test_extract_student_name_from_pdf_calls_openai(
+    def test_extract_student_name_from_pdf_calls_llm(
         self, mock_get_repo: MagicMock, mock_pdf_reader: MagicMock
     ) -> None:
-        """Test that OpenAI is called when initial extraction returns Unknown."""
+        """Test that LLM is called when initial extraction returns Unknown."""
         mock_page = MagicMock()
         mock_page.extract_text.return_value = "Some text without a clear name pattern"
 
@@ -507,12 +507,12 @@ class TestDeliverableService:
         mock_pdf_reader.return_value = mock_reader_instance
 
         service = DeliverableService()
-        service.openai_api_key = "test_api_key"
+        service.llm_api_key = "test_api_key"
 
-        with patch.object(service, "extract_name_with_openai", return_value="John Doe") as mock_openai:
+        with patch.object(service, "extract_name_with_llm", return_value="John Doe") as mock_llm:
             name, _ = service.extract_student_name_from_pdf(b"pdf content")  # type: ignore
 
-            mock_openai.assert_called_once()
+            mock_llm.assert_called_once()
             assert name == "John Doe"
 
     @patch("src.service.deliverable_service.get_database_repository")


### PR DESCRIPTION
- Rename OPENAI_API_KEY to LLM_API_KEY environment variable
- Add base_url config for custom API endpoints (OpenRouter, Mistral, etc.)
- Add model config with default gpt-4o-mini
- Update deliverable_service to use config for model/base_url
- Rename extract_name_with_openai to extract_name_with_llm
- Update all tests and log messages

BREAKING CHANGE: OPENAI_API_KEY env var renamed to LLM_API_KEY

- Fixes #61 